### PR TITLE
Add comic book format property

### DIFF
--- a/Cbr.Net/ComicBook.cs
+++ b/Cbr.Net/ComicBook.cs
@@ -13,6 +13,11 @@ namespace Cbr.Net
         private readonly List<string> _entries = new List<string>();
 
         /// <summary>
+        /// Gets the format of the comic book container.
+        /// </summary>
+        public ComicBookFormat Format { get; private set; }
+
+        /// <summary>
         /// Creates a <see cref="ComicBook"/> from the specified file.
         /// </summary>
         /// <param name="path">Path to the comic book archive.</param>
@@ -34,6 +39,7 @@ namespace Cbr.Net
                     throw new NotSupportedException($"Format '{format}' is not yet supported.");
             }
 
+            book.Format = format;
             return book;
         }
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Supported container formats:
   implemented using additional archive libraries.
 
 The main entry point is `ComicBook.Load(path)` which loads a comic book and
-provides access to its entries (pages).
+provides access to its entries (pages). The resulting `ComicBook` instance
+exposes the container format through the `Format` property.
 
 ## License
 


### PR DESCRIPTION
## Summary
- expose `ComicBook.Format` to publish the loaded archive's format
- set the format when loading a book
- document the new property in README
